### PR TITLE
Mouse up while off menu better not trigger hovered command

### DIFF
--- a/cytoscape-cxtmenu.js
+++ b/cytoscape-cxtmenu.js
@@ -60,6 +60,7 @@
       var r = options.menuRadius;
       var containerSize = (r + options.activePadding)*2;
       var activeCommandI = undefined;
+      var lock = false;
       var offset;
 
       $container.append( $wrapper );
@@ -145,6 +146,15 @@
               select.apply(target);
           }
         }
+      });
+
+      $wrapper.on('mouseleave', function() {
+        lock = true;
+        activeCommandI = undefined;
+      });
+
+      $wrapper.on('mouseenter', function() {
+        lock = false;
       });
 
 
@@ -331,8 +341,10 @@
                 c2d.closePath();
                 c2d.fill();
                 //c2d.stroke();
-
-                activeCommandI = i;
+                if (!lock) {
+                  activeCommandI = i;  
+                }
+                
 
                 break;
               }


### PR DESCRIPTION
This might be just my current opinion:
When the mouse is up but the mouse pointer is somewhere else far from the menu already, even though one of the commands is hovered, it should not be triggered to surprise users. As far as I see, command should only be triggered when mouse pointer is on the menu.

However, feel free to ignore this pull request if you think otherwise :)