### PR TITLE
Don't autoHide menu when mouse is released and don't select option when off menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cytoscape-cxtmenu",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A context menu for Cytoscape.js",
   "main": "cytoscape-cxtmenu.js",
   "scripts": {


### PR DESCRIPTION
I didn't see the other pull request about the menu item selected, so sorry for the duplicate there, but I also don't think the menu item should be selected if the mouse is off of the menu item. I fixed this differently than he did though. 

In addition to that issue, I have also added a new `autoHide` option so you don't have to hold right click to keep the menu open.  I move the mouse movement code into a function to be used in both cases (i.e. ctxdrag and mousemove events).  `autoHide=true` is the default (and previous) behavior.  If `autoHide = false`, when you right click, the menu stays there until to left click.  