### PR TITLE
Add "cytoscape" and "jquery" as dependencies in the bower manifest file....

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,10 @@
     "type": "git",
     "url": "https://github.com/cytoscape/cytoscape.js-cxtmenu.git"
   },
+  "dependencies": {
+    "cytoscape": ">= 2.2",
+    "jquery":">=1.4"
+  },
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
... Allows ultilies such as wiredep to correctly arrange cytoscape plugin dependency.