### PR TITLE
Test if grabbable is an existing function before calling 

### DIFF
--- a/cytoscape-cxtmenu.js
+++ b/cytoscape-cxtmenu.js
@@ -268,7 +268,7 @@
             var ele = this;
             var isCy = this === cy;
 
-            grabbable = target.grabbable();
+            grabbable = target.grabble &&  target.grabbable();
             if( grabbable ){
               target.ungrabify();
             }


### PR DESCRIPTION
target.grabbable() will crash out when right clicking on background.
Change does result in no error in console and menu appearing on background, however it may be avoiding the problem rather than solving it, I haven't really read around the code to see if it is correct to have arrived at this line of code.