### PR TITLE
Remove selector on (cxt)tapend handler

### DIFF
--- a/cytoscape-cxtmenu.js
+++ b/cytoscape-cxtmenu.js
@@ -463,8 +463,8 @@ SOFTWARE.
 
           .on('tapdrag', dragHandler)
 
-          .on('cxttapend tapend', options.selector, function(e){
-            var ele = this;
+          .on('cxttapend tapend', function(e){
+            var ele = target;
             $parent.hide();
 
             if( activeCommandI !== undefined ){
@@ -475,16 +475,6 @@ SOFTWARE.
                 activeCommandI = undefined;
               }
             }
-
-            inGesture = false;
-
-            restoreGrab();
-            restoreZoom();
-            restorePan();
-          })
-
-          .on('cxttapend tapend', function(e){
-            $parent.hide();
 
             inGesture = false;
 


### PR DESCRIPTION
This fixes #37 for me and makes the demo act in a reasonable way. My reasoning is that when you set a selector for a menu, you intend to filter on where the menu should pop up, not on where the mouse should be after a selection is made in the menu.

This serves my needs – please let me know if it is appropriate for general use.

Thanks!