### PR TITLE
Make destroy() to remove menu handlers registered on core

### DIFF
--- a/cytoscape-cxtmenu.js
+++ b/cytoscape-cxtmenu.js
@@ -296,20 +296,26 @@ SOFTWARE.
 
       var bindings = {
         on: function(events, selector, fn){
-          data.handlers.push({
-            events: events,
-            selector: selector,
-            fn: fn
-          });
-
-          if( selector === 'core' ){
-            cy.on(events, function( e ){
+          
+          var _fn = fn;
+          if( selector === 'core'){
+            _fn = function( e ){
               if( e.cyTarget === cy ){ // only if event target is directly core
                 return fn.apply( this, [ e ] );
               }
-            });
+            };
+          }
+          
+          data.handlers.push({
+            events: events,
+            selector: selector,
+            fn: _fn
+          });
+
+          if( selector === 'core' ){
+            cy.on(events, _fn);
           } else {
-            cy.on(events, selector, fn);
+            cy.on(events, selector, _fn);
           }
 
           return this;


### PR DESCRIPTION
I want to have different menus depending on my application mode.
Problem:
When calling destroy(), cytoscape-cxtmenu doesn't remove event handlers registered for selector === 'core'. After several destroy() and creations of a new menu this results in multiple calls of previously defined and removed menu commands on a single user selection.
- - -
Hope this pull request solve this problem