### PR TITLE
fixed error in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ var defaults = {
     /*
     { // example command
       fillColor: 'rgba(200, 200, 200, 0.75)', // optional: custom background color for item
-      content: 'a command name' // html/text content to be displayed in the menu
+      content: 'a command name', // html/text content to be displayed in the menu
       select: function(ele){ // a function to execute when the command is selected
         console.log( ele.id() ) // `ele` holds the reference to the active element
       }


### PR DESCRIPTION
I fixed a small issue in the README where the example stating the default options was missing a comma in the example command.