### PR TITLE
mouse position related modifications

### DIFF
--- a/cytoscape-cxtmenu.js
+++ b/cytoscape-cxtmenu.js
@@ -355,6 +355,16 @@ SOFTWARE.
             var ele = this;
             var isCy = this === cy;
 
+            if (inGesture) {
+              $parent.hide();
+
+              inGesture = false;
+
+              restoreGrab();
+              restoreZoom();
+              restorePan();
+            }
+
             if( typeof options.commands === 'function' ){
               commands = options.commands(target);
             } else {

--- a/cytoscape-cxtmenu.js
+++ b/cytoscape-cxtmenu.js
@@ -374,7 +374,7 @@ SOFTWARE.
             }
 
             var rp, rw, rh;
-            if( !isCy && ele.isNode() && !options.atMouse ){
+            if( !isCy && ele.isNode() && !ele.isParent() && !options.atMouse ){
               rp = ele.renderedPosition();
               rw = ele.renderedWidth();
               rh = ele.renderedHeight();

--- a/cytoscape-cxtmenu.js
+++ b/cytoscape-cxtmenu.js
@@ -329,6 +329,7 @@ SOFTWARE.
         var dragHandler;
         var zoomEnabled;
         var panEnabled;
+        var gestureStartEvent;
 
         var restoreZoom = function(){
           if( zoomEnabled ){
@@ -405,6 +406,7 @@ SOFTWARE.
             activeCommandI = undefined;
 
             inGesture = true;
+            gestureStartEvent = e;
           })
 
           .on('cxtdrag tapdrag', options.selector, dragHandler = function(e){
@@ -478,7 +480,7 @@ SOFTWARE.
               var select = commands[ activeCommandI ].select;
 
               if( select ){
-                select.apply( ele, [ele] );
+                select.apply( ele, [ele, gestureStartEvent] );
                 activeCommandI = undefined;
               }
             }


### PR DESCRIPTION
centered position on big compound nodes not comfortable, context menu could be out of screen if compounds center is out of screen.

"original event" is most useful on "core" events, for example to create node at place where context menu was called