### PR TITLE
#51 do the action on tap not on tapend

### DIFF
--- a/cytoscape-cxtmenu.js
+++ b/cytoscape-cxtmenu.js
@@ -542,32 +542,20 @@ SOFTWARE.
 
           .on('tapdrag', dragHandler)
 
-          .on('cxttapend tapend', options.selector, function(e){
+          .on('cxttap tap', options.selector, function(e){
             var ele = this;
-
-            parent.style.display = 'none';
-
             if( activeCommandI !== undefined ){
               var select = commands[ activeCommandI ].select;
-
               if( select ){
                 select.apply( ele, [ele, gestureStartEvent] );
                 activeCommandI = undefined;
               }
             }
-
-            inGesture = false;
-
-            restoreGrab();
-            restoreZoom();
-            restorePan();
           })
 
           .on('cxttapend tapend', function(e){
             parent.style.display = 'none';
-
             inGesture = false;
-
             restoreGrab();
             restoreZoom();
             restorePan();

--- a/cytoscape-cxtmenu.js
+++ b/cytoscape-cxtmenu.js
@@ -554,6 +554,16 @@ SOFTWARE.
           })
 
           .on('cxttapend tapend', function(e){
+            if (options.openMenuEvents === 'tap') {
+              var ele = this
+              if (activeCommandI !== undefined) {
+                var select = commands[ activeCommandI ].select
+                if (select) {
+                  select.apply(ele, [ele, gestureStartEvent])
+                  activeCommandI = undefined
+                }
+              }
+            }
             parent.style.display = 'none';
             inGesture = false;
             restoreGrab();


### PR DESCRIPTION
This fixes the issue at hand. Instead of waiting for `tapend` it will trigger on tap, so if you have `taphold`, which is default it will do the action when you let go.

Works in `demo.html`