### PR TITLE
fix for pages with "rtl" direction

### DIFF
--- a/cytoscape-cxtmenu.js
+++ b/cytoscape-cxtmenu.js
@@ -152,6 +152,8 @@ SOFTWARE.
 
       setStyles(wrapper, {
         position: 'absolute',
+		top:0,
+		left:0,
         zIndex: options.zIndex
       });
 


### PR DESCRIPTION
On pages with "right to left" direction. Default absolute position is right top corner. Right now context menu is out of screen on such pages.