### PR TITLE
Fix syntax error in Example Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ let defaults = {
     /*
     { // example command
       fillColor: 'rgba(200, 200, 200, 0.75)', // optional: custom background color for item
-      content: 'a command name' // html/text content to be displayed in the menu
+      content: 'a command name', // html/text content to be displayed in the menu
       contentStyle: {}, // css key:value pairs to set the command's css in js if you want
       select: function(ele){ // a function to execute when the command is selected
         console.log( ele.id() ) // `ele` holds the reference to the active element


### PR DESCRIPTION
Hi All

While working through your example, I found a minor syntax error: 
- The first object in the example 'commands' array is missing a comma.

Thanks for the great tool