### PR TITLE
Adaptative menu size improvement with adaptative spotlight radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ let cy = cytoscape({
 
 // the default values of each option are outlined below:
 let defaults = {
-  menuRadius: function(ele){ return 100; }, // the outer radius (node center to the end of the menu) in pixels. It is added to the rendered size of the node. 
+  menuRadius: function(ele){ return 100; }, // the outer radius (node center to the end of the menu) in pixels. It is added to the rendered size of the node. Can either be a number or function as in the example.
   selector: 'node', // elements matching this Cytoscape.js selector will trigger cxtmenus
   commands: [ // an array of commands to list in the menu or a function that returns the array
     /*
@@ -93,8 +93,8 @@ let defaults = {
   indicatorSize: 24, // the size in pixels of the pointer to the active command
   separatorWidth: 3, // the empty spacing in pixels between successive commands
   spotlightPadding: 4, // extra spacing in pixels between the element and the spotlight
-  minSpotlightRadius: 24, // the minimum radius in pixels of the spotlight
-  maxSpotlightRadius: 38, // the maximum radius in pixels of the spotlight
+  minSpotlightRadius: 24, // the minimum radius in pixels of the spotlight, set to undefined if you want the spotlight to be size of the node.
+  maxSpotlightRadius: 38, // the maximum radius in pixels of the spotlight, set to undefined if you want the spotlight to be size of the node.
   openMenuEvents: 'cxttapstart taphold', // space-separated cytoscape events that will open the menu; only `cxttapstart` and/or `taphold` work here
   itemColor: 'white', // the colour of text in the command's content
   itemTextShadowColor: 'transparent', // the text shadow colour of the command's content

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ cytoscape-cxtmenu
 
 ## Description
 
-A circular, swipeable context menu extension for Cytoscape.js ([demo](https://cytoscape.github.io/cytoscape.js-cxtmenu))
+A circular, swipeable context menu extension for Cytoscape.js 
+- Demo without adaptative spotlight radius features: [demo](https://cytoscape.github.io/cytoscape.js-cxtmenu)
+- Demo with adaptative spotlight radius features: [demo](https://cytoscape.github.io/cytoscape.js-cxtmenu/demo-adaptative.html) 
 
 This extension creates a widget that lets the user operate circular context menus on nodes in Cytoscape.js.  The user swipes along the circular menu to select a menu item and perform a command on either a node, a edge, or the graph background.
 
@@ -90,7 +92,7 @@ let defaults = {
   fillColor: 'rgba(0, 0, 0, 0.75)', // the background colour of the menu
   activeFillColor: 'rgba(1, 105, 217, 0.75)', // the colour used to indicate the selected command
   activePadding: 20, // additional size in pixels for the active command
-  indicatorSize: 24, // the size in pixels of the pointer to the active command
+  indicatorSize: 24, // the size in pixels of the pointer to the active command, will default to the node size if the node size is smaller than the indicator size, 
   separatorWidth: 3, // the empty spacing in pixels between successive commands
   spotlightPadding: 4, // extra spacing in pixels between the element and the spotlight
   adaptativeNodeSpotlightRadius: false, // specify whether the spotlight radius should adapt to the node size

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ let defaults = {
   indicatorSize: 24, // the size in pixels of the pointer to the active command
   separatorWidth: 3, // the empty spacing in pixels between successive commands
   spotlightPadding: 4, // extra spacing in pixels between the element and the spotlight
-  minSpotlightRadius: 24, // the minimum radius in pixels of the spotlight, set to undefined if you want the spotlight to be size of the node.
-  maxSpotlightRadius: 38, // the maximum radius in pixels of the spotlight, set to undefined if you want the spotlight to be size of the node.
+  adaptativeNodeSpotlightRadius: false, // specify whether the spotlight radius should adapt to the node size
+  minSpotlightRadius: 24, // the minimum radius in pixels of the spotlight (ignored for the node if adaptativeNodeSpotlightRadius is enabled but still used for the edge & background)
+  maxSpotlightRadius: 38, // the maximum radius in pixels of the spotlight (ignored for the node if adaptativeNodeSpotlightRadius is enabled but still used for the edge & background)
   openMenuEvents: 'cxttapstart taphold', // space-separated cytoscape events that will open the menu; only `cxttapstart` and/or `taphold` work here
   itemColor: 'white', // the colour of text in the command's content
   itemTextShadowColor: 'transparent', // the text shadow colour of the command's content

--- a/demo-adaptative.html
+++ b/demo-adaptative.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+
+<html>
+
+	<head>
+		<title>cytoscape-cxtmenu.js demo with adaptative spotlight</title>
+
+		<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
+
+		<link href="https://unpkg.com/font-awesome@4.7.0/css/font-awesome.min.css" rel="stylesheet" type="text/css" />
+		<script src="https://unpkg.com/cytoscape/dist/cytoscape.min.js"></script>
+
+		<!-- for testing with local version of cytoscape.js -->
+		<!--<script src="../cytoscape.js/build/cytoscape.js"></script>-->
+
+		<script src="cytoscape-cxtmenu.js"></script>
+
+		<style>
+			body {
+				font-family: helvetica;
+				font-size: 14px;
+				overflow: hidden;
+			}
+
+			#cy {
+				width: 100%;
+				height: 100%;
+				position: absolute;
+				left: 0;
+				top: 0;
+				z-index: 999;
+			}
+
+			h1 {
+				opacity: 0.5;
+				font-size: 1em;
+			}
+
+			/* you can set the disabled style how you like on the text/icon */
+			.cxtmenu-disabled {
+				opacity: 0.333;
+			}
+		</style>
+
+		<script>
+			window.addEventListener('DOMContentLoaded', function(){
+
+				var cy = window.cy = cytoscape({
+					container: document.getElementById('cy'),
+
+					ready: function(){
+					},
+
+					style: [
+						{
+							selector: 'node',
+							css: {
+								'content': 'data(name)'
+							}
+						},
+						{
+							selector: 'node[id="j"]',
+							css: {
+								'width': 100,
+            					'height': 100,
+							}
+						},
+						{
+							selector: 'node[id="e"]',
+							css: {
+								'width': 150,
+            					'height': 150,
+							}
+						},
+						{
+							selector: 'node[id="k"]',
+							css: {
+								'width': 20,
+            					'height': 20,
+							}
+						},
+						{
+							selector: 'edge',
+							css: {
+								'curve-style': 'bezier',
+								'target-arrow-shape': 'triangle'
+							}
+						}
+					],
+
+					elements: {
+						nodes: [
+							{ data: { id: 'j', name: 'Non-adaptative spotlight medium node' } },
+							{ data: { id: 'e', name: 'Adaptative spotlight big node' } },
+							{ data: { id: 'k', name: 'Adaptative spotlight small node' } },
+							{ data: { id: 'g', name: 'Non-adaptative normal node' } }
+						],
+						edges: [
+							{ data: { source: 'j', target: 'e' } },
+							{ data: { source: 'j', target: 'k' } },
+							{ data: { source: 'j', target: 'g' } },
+							{ data: { source: 'e', target: 'j' } },
+							{ data: { source: 'e', target: 'k' } },
+							{ data: { source: 'k', target: 'j' } },
+							{ data: { source: 'k', target: 'e' } },
+							{ data: { source: 'k', target: 'g' } },
+							{ data: { source: 'g', target: 'j' } }
+						]
+					}
+				});
+
+				cy.cxtmenu({
+					selector: 'node[id="j"], node[id="g"], edge',
+					adaptativeNodeSpotlightRadius: false,
+					commands: [
+						{
+							content: '<span class="fa fa-flash fa-2x"></span>',
+							select: function(ele){
+								console.log( ele.id() );
+							}
+						},
+
+						{
+							content: '<span class="fa fa-star fa-2x"></span>',
+							select: function(ele){
+								console.log( ele.data('name') );
+							},
+							enabled: false
+						},
+
+						{
+							content: 'Text',
+							select: function(ele){
+								console.log( ele.position() );
+							}
+						}
+					]
+				});
+
+				cy.cxtmenu({
+					selector: 'node[id="e"], node[id="k"]',
+					adaptativeNodeSpotlightRadius: true,
+					commands: [
+						{
+							content: '<span class="fa fa-flash fa-2x"></span>',
+							select: function(ele){
+								console.log( ele.id() );
+							}
+						},
+
+						{
+							content: '<span class="fa fa-star fa-2x"></span>',
+							select: function(ele){
+								console.log( ele.data('name') );
+							},
+							enabled: false
+						},
+
+						{
+							content: 'Text',
+							select: function(ele){
+								console.log( ele.position() );
+							}
+						}
+					]
+				});
+
+				cy.cxtmenu({
+					selector: 'core',
+
+					commands: [
+						{
+							content: 'bg1',
+							select: function(){
+								console.log( 'bg1' );
+							}
+						},
+
+						{
+							content: 'bg2',
+							select: function(){
+								console.log( 'bg2' );
+							}
+						}
+					]
+				});
+
+			});
+		</script>
+	</head>
+
+	<body>
+		<h1>cytoscape-cxtmenu demo with adaptative spotlight</h1>
+
+		<div id="cy"></div>
+
+	</body>
+
+</html>

--- a/pages/demo-adaptative.html
+++ b/pages/demo-adaptative.html
@@ -1,0 +1,1 @@
+../demo-adaptative.html

--- a/src/cxtmenu.js
+++ b/src/cxtmenu.js
@@ -74,8 +74,8 @@ let cxtmenu = function(params){
 
       // Arbitrary multiplier to increase the sizing of the space 
       // available for the item.
-      let width =  1.5 * Math.abs((r - rs) * Math.cos(midtheta));
-      let height = 1.5 * Math.abs((r - rs) * Math.sin(midtheta));
+      let width = 1 * Math.abs((r - rs) * Math.cos(midtheta));
+      let height = 1 * Math.abs((r - rs) * Math.sin(midtheta));
       width = Math.max(width, height)
 
       let item = createElement({class: 'cxtmenu-item'});
@@ -409,26 +409,31 @@ let cxtmenu = function(params){
             target.ungrabify();
           }
 
-          let rp, rw, rh;
-          if( !isCy && ele.isNode() && !ele.isParent() && !options.atMouse ){
+          let rp, rw, rh, rs;
+          if( !isCy && ele && ele.isNode instanceof Function && ele.isNode() && !ele.isParent() && !options.atMouse ){
+            // If it's a node, the default spotlight radius for a node is the node width
             rp = ele.renderedPosition();
             rw = ele.renderedOuterWidth();
             rh = ele.renderedOuterHeight();
+            rs = rw/2;
+            // If adaptativeNodespotlightRadius is not enabled and min|maxSpotlighrRadius is defined, use those instead
+            rs = !options.adaptativeNodeSpotlightRadius && options.minSpotlightRadius ? Math.max(rs, options.minSpotlightRadius): rs;
+            rs = !options.adaptativeNodeSpotlightRadius && options.maxSpotlightRadius ? Math.min(rs, options.maxSpotlightRadius): rs;
           } else {
+            // If it's the background or an edge, the spotlight radius is the min|maxSpotlightRadius
             rp = e.renderedPosition || e.cyRenderedPosition;
             rw = 1;
             rh = 1;
+            rs = rw/2;
+            rs = options.minSpotlightRadius ? Math.max(rs, options.minSpotlightRadius): rs;
+            rs = options.maxSpotlightRadius ? Math.min(rs, options.maxSpotlightRadius): rs;
           }
 
           offset = getOffset(container);
 
           ctrx = rp.x;
           ctry = rp.y;
-
           r = rw/2 + (options.menuRadius instanceof Function ? options.menuRadius(target) : Number(options.menuRadius));
-          rs = Math.max(rw, rh)/2;
-          rs = options.minSpotlightRadius ? Math.max(rs, options.minSpotlightRadius): rs;
-          rs = options.maxSpotlightRadius ? Math.min(rs, options.maxSpotlightRadius): rs;
           containerSize = (r + options.activePadding)*2;
           updatePixelRatio();
 
@@ -473,15 +478,21 @@ let cxtmenu = function(params){
 
         let rw;
         if(target && target.isNode instanceof Function && target.isNode() && !target.isParent() && !options.atMouse ){
+          // If it's a node, the default spotlight radius for a node is the node width
           rw = target.renderedOuterWidth();
+          rs = rw/2;
+          // If adaptativeNodespotlightRadius is not enabled and min|maxSpotlighrRadius is defined, use those instead
+          rs = !options.adaptativeNodeSpotlightRadius && options.minSpotlightRadius ? Math.max(rs, options.minSpotlightRadius): rs;
+          rs = !options.adaptativeNodeSpotlightRadius && options.maxSpotlightRadius ? Math.min(rs, options.maxSpotlightRadius): rs;
         } else {
+          // If it's the background or an edge, the spotlight radius is the min|maxSpotlightRadius
           rw = 1;
+          rs = rw/2;
+          rs = options.minSpotlightRadius ? Math.max(rs, options.minSpotlightRadius): rs;
+          rs = options.maxSpotlightRadius ? Math.min(rs, options.maxSpotlightRadius): rs;
         }
 
         r = rw/2 + (options.menuRadius instanceof Function ? options.menuRadius(target) : Number(options.menuRadius));
-        rs = rw/2;
-        rs = options.maxSpotlightRadius ? Math.max(rs, options.maxSpotlightRadius): rs;
-        rs = options.maxSpotlightRadius ? Math.min(rs, options.maxSpotlightRadius): rs;
         if( d < rs + options.spotlightPadding ){
           queueDrawBg(r, rs);
           return;

--- a/src/cxtmenu.js
+++ b/src/cxtmenu.js
@@ -189,11 +189,11 @@ let cxtmenu = function(params){
     c2d.globalCompositeOperation = 'source-over';
   }
 
-  function queueDrawCommands( rx, ry, radius, theta ){
-    redrawQueue.drawCommands = [ rx, ry, radius, theta ];
+  function queueDrawCommands( rx, ry, radius, theta, rspotlight ){
+    redrawQueue.drawCommands = [ rx, ry, radius, theta, rspotlight ];
   }
 
-  function drawCommands( rx, ry, radius, theta ){
+  function drawCommands( rx, ry, radius, theta, rs ){
     let dtheta = 2*Math.PI/(commands.length);
     let theta1 = Math.PI/2;
     let theta2 = theta1 + dtheta;
@@ -221,8 +221,11 @@ let cxtmenu = function(params){
     c2d.rotate( rot );
 
     // clear the indicator
+    // The indicator size (arrow) depends on the node size as well. If the indicator size is bigger and the rendered node size + padding, 
+    // use the rendered node size + padding as the indicator size.
+    let indicatorSize = options.indicatorSize > rs + options.spotlightPadding ? rs + options.spotlightPadding : options.indicatorSize
     c2d.beginPath();
-    c2d.fillRect(-options.indicatorSize/2, -options.indicatorSize/2, options.indicatorSize, options.indicatorSize);
+    c2d.fillRect(-indicatorSize/2, -indicatorSize/2, indicatorSize, indicatorSize);
     c2d.closePath();
     c2d.fill();
 
@@ -529,7 +532,7 @@ let cxtmenu = function(params){
           theta2 += dtheta;
         }
 
-        queueDrawCommands( rx, ry, r, theta );
+        queueDrawCommands( rx, ry, r, theta, rs );
       })
 
       .on('tapdrag', dragHandler)

--- a/src/cxtmenu.js
+++ b/src/cxtmenu.js
@@ -59,7 +59,7 @@ let cxtmenu = function(params){
   canvas.width = containerSize;
   canvas.height = containerSize;
 
-  function createMenuItems() {
+  function createMenuItems(r, rs) {
     removeEles('.cxtmenu-item', parent);
     let dtheta = 2 * Math.PI / (commands.length);
     let theta1 = Math.PI / 2;
@@ -69,8 +69,14 @@ let cxtmenu = function(params){
       let command = commands[i];
 
       let midtheta = (theta1 + theta2) / 2;
-      let rx1 = 0.66 * r * Math.cos(midtheta);
-      let ry1 = 0.66 * r * Math.sin(midtheta);
+      let rx1 = ((r + rs)/2) * Math.cos(midtheta);
+      let ry1 = ((r + rs)/2) * Math.sin(midtheta);
+
+      // Arbitrary multiplier to increase the sizing of the space 
+      // available for the item.
+      let width =  1.5 * Math.abs((r - rs) * Math.cos(midtheta));
+      let height = 1.5 * Math.abs((r - rs) * Math.sin(midtheta));
+      width = Math.max(width, height)
 
       let item = createElement({class: 'cxtmenu-item'});
       setStyles(item, {
@@ -83,11 +89,11 @@ let cxtmenu = function(params){
         'text-shadow': '-1px -1px 2px ' + options.itemTextShadowColor + ', 1px -1px 2px ' + options.itemTextShadowColor + ', -1px 1px 2px ' + options.itemTextShadowColor + ', 1px 1px 1px ' + options.itemTextShadowColor,
         left: '50%',
         top: '50%',
-        'min-height': (r * 0.66) + 'px',
-        width: (r * 0.66) + 'px',
-        height: (r * 0.66) + 'px',
-        marginLeft: (rx1 - r * 0.33) + 'px',
-        marginTop: (-ry1 - r * 0.33) + 'px'
+        'min-height': width + 'px',
+        width: width + 'px',
+        height: width + 'px',
+        marginLeft: (rx1 - width/2) + 'px',
+        marginTop: (-ry1 - width/2) + 'px'
       });
 
       let content = createElement({class: 'cxtmenu-content'});
@@ -99,10 +105,10 @@ let cxtmenu = function(params){
       }
 
       setStyles(content, {
-        'width': (r * 0.66) + 'px',
-        'height': (r * 0.66) + 'px',
+        'width': width + 'px',
+        'height': width + 'px',
         'vertical-align': 'middle',
-        'display': 'table-cell'
+        'display': 'table-cell',
       });
 
       setStyles(content, command.contentStyle || {});
@@ -124,7 +130,6 @@ let cxtmenu = function(params){
   }
 
   function drawBg( radius, rspotlight ){
-    rspotlight = rspotlight !== undefined ? rspotlight : rs;
     c2d.globalCompositeOperation = 'source-over';
 
     c2d.clearRect(0, 0, containerSize, containerSize);
@@ -421,6 +426,9 @@ let cxtmenu = function(params){
           ctry = rp.y;
 
           r = rw/2 + (options.menuRadius instanceof Function ? options.menuRadius(target) : Number(options.menuRadius));
+          rs = Math.max(rw, rh)/2;
+          rs = options.minSpotlightRadius ? Math.max(rs, options.minSpotlightRadius): rs;
+          rs = options.maxSpotlightRadius ? Math.min(rs, options.maxSpotlightRadius): rs;
           containerSize = (r + options.activePadding)*2;
           updatePixelRatio();
 
@@ -431,13 +439,8 @@ let cxtmenu = function(params){
             left: (rp.x - r) + 'px',
             top: (rp.y - r) + 'px'
           });
-          createMenuItems();
-
-          rs = Math.max(rw, rh)/2;
-          rs = Math.max(rs, options.minSpotlightRadius);
-          rs = Math.min(rs, options.maxSpotlightRadius);
-
-          queueDrawBg(r);
+          createMenuItems(r, rs);
+          queueDrawBg(r, rs);
 
           activeCommandI = undefined;
 
@@ -476,11 +479,14 @@ let cxtmenu = function(params){
         }
 
         r = rw/2 + (options.menuRadius instanceof Function ? options.menuRadius(target) : Number(options.menuRadius));
+        rs = rw/2;
+        rs = options.maxSpotlightRadius ? Math.max(rs, options.maxSpotlightRadius): rs;
+        rs = options.maxSpotlightRadius ? Math.min(rs, options.maxSpotlightRadius): rs;
         if( d < rs + options.spotlightPadding ){
-          queueDrawBg(r);
+          queueDrawBg(r, rs);
           return;
         }
-        queueDrawBg(r);
+        queueDrawBg(r, rs);
 
         let rx = dx*r / d;
         let ry = dy*r / d;

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -17,7 +17,7 @@ let defaults = {
   fillColor: 'rgba(0, 0, 0, 0.75)', // the background colour of the menu
   activeFillColor: 'rgba(1, 105, 217, 0.75)', // the colour used to indicate the selected command
   activePadding: 20, // additional size in pixels for the active command
-  indicatorSize: 24, // the size in pixels of the pointer to the active command
+  indicatorSize: 24, // the size in pixels of the pointer to the active command, will default to the node size if the node size is smaller than the indicator size, 
   separatorWidth: 3, // the empty spacing in pixels between successive commands
   spotlightPadding: 4, // extra spacing in pixels between the element and the spotlight
   adaptativeNodeSpotlightRadius: false, // specify whether the spotlight radius should adapt to the node size

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -20,8 +20,9 @@ let defaults = {
   indicatorSize: 24, // the size in pixels of the pointer to the active command
   separatorWidth: 3, // the empty spacing in pixels between successive commands
   spotlightPadding: 4, // extra spacing in pixels between the element and the spotlight
-  minSpotlightRadius: 24, // the minimum radius in pixels of the spotlight
-  maxSpotlightRadius: 38, // the maximum radius in pixels of the spotlight
+  adaptativeNodeSpotlightRadius: false, // specify whether the spotlight radius should adapt to the node size
+  minSpotlightRadius: 24, // the minimum radius in pixels of the spotlight (ignored for the node if adaptativeNodeSpotlightRadius is enabled but still used for the edge & background)
+  maxSpotlightRadius: 38, // the maximum radius in pixels of the spotlight (ignored for the node if adaptativeNodeSpotlightRadius is enabled but still used for the edge & background)
   openMenuEvents: 'cxttapstart taphold', // space-separated cytoscape events that will open the menu; only `cxttapstart` and/or `taphold` work here
   itemColor: 'white', // the colour of text in the command's content
   itemTextShadowColor: 'transparent', // the text shadow colour of the command's content


### PR DESCRIPTION
Adaptative menu size improvement with adaptative spotlight radius support
- Spotlight radius will now be equal to the node rendered size  if no min|maxSpotlightRadius is specified.