### PR TITLE
Implemented outsideMenuCancel option

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ let defaults = {
   itemColor: 'white', // the colour of text in the command's content
   itemTextShadowColor: 'transparent', // the text shadow colour of the command's content
   zIndex: 9999, // the z-index of the ui div
-  atMouse: false // draw menu at mouse position
+  atMouse: false, // draw menu at mouse position
+  outsideMenuCancel: false // if set to a number, this will cancel the command if the pointer is released outside of the spotlight, padded by the number given 
 };
 
 let menu = cy.cxtmenu( defaults );

--- a/cytoscape-cxtmenu.js
+++ b/cytoscape-cxtmenu.js
@@ -589,7 +589,7 @@ var cxtmenu = function cxtmenu(params) {
       }
 
       r = rw / 2 + (options.menuRadius instanceof Function ? options.menuRadius(target) : Number(options.menuRadius));
-      if (d < rs + options.spotlightPadding || options.outsideMenuCancel && d > r + options.activePadding) {
+      if (d < rs + options.spotlightPadding || typeof options.outsideMenuCancel === "number" && d > r + options.activePadding + options.outsideMenuCancel) {
         //
 
         queueDrawBg(r, rs);
@@ -742,7 +742,7 @@ var defaults = {
   itemTextShadowColor: 'transparent', // the text shadow colour of the command's content
   zIndex: 9999, // the z-index of the ui div
   atMouse: false, // draw menu at mouse position
-  outsideMenuCancel: false // if true, this will cancel the command if the pointer is released outside of the spotlight
+  outsideMenuCancel: false // if set to a number, this will cancel the command if the pointer is released outside of the spotlight, padded by the number given
 };
 
 module.exports = defaults;

--- a/cytoscape-cxtmenu.js
+++ b/cytoscape-cxtmenu.js
@@ -589,7 +589,9 @@ var cxtmenu = function cxtmenu(params) {
       }
 
       r = rw / 2 + (options.menuRadius instanceof Function ? options.menuRadius(target) : Number(options.menuRadius));
-      if (d < rs + options.spotlightPadding) {
+      if (d < rs + options.spotlightPadding || options.outsideMenuCancel && d > r + options.activePadding) {
+        //
+
         queueDrawBg(r, rs);
         return;
       }
@@ -623,11 +625,9 @@ var cxtmenu = function cxtmenu(params) {
         theta1 += dtheta;
         theta2 += dtheta;
       }
-
       queueDrawCommands(rx, ry, r, theta, rs);
     }).on('tapdrag', dragHandler).on('cxttapend tapend', function () {
       parent.style.display = 'none';
-
       if (activeCommandI !== undefined) {
         var select = commands[activeCommandI].select;
 
@@ -741,7 +741,8 @@ var defaults = {
   itemColor: 'white', // the colour of text in the command's content
   itemTextShadowColor: 'transparent', // the text shadow colour of the command's content
   zIndex: 9999, // the z-index of the ui div
-  atMouse: false // draw menu at mouse position
+  atMouse: false, // draw menu at mouse position
+  outsideMenuCancel: false // if true, this will cancel the command if the pointer is released outside of the spotlight
 };
 
 module.exports = defaults;

--- a/demo-cancel-outside.html
+++ b/demo-cancel-outside.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+
+<html>
+
+	<head>
+		<title>cytoscape-cxtmenu.js cancel outside demo</title>
+
+		<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
+
+		<link href="https://unpkg.com/font-awesome@4.7.0/css/font-awesome.min.css" rel="stylesheet" type="text/css" />
+		<script src="https://unpkg.com/cytoscape/dist/cytoscape.min.js"></script>
+
+		<!-- for testing with local version of cytoscape.js -->
+		<!--<script src="../cytoscape.js/build/cytoscape.js"></script>-->
+
+		<script src="cytoscape-cxtmenu.js"></script>
+
+		<style>
+			body {
+				font-family: helvetica;
+				font-size: 14px;
+				overflow: hidden;
+			}
+
+			#cy {
+				width: 100%;
+				height: 100%;
+				position: absolute;
+				left: 0;
+				top: 0;
+				z-index: 999;
+			}
+
+			h1 {
+				opacity: 0.5;
+				font-size: 1em;
+			}
+
+			/* you can set the disabled style how you like on the text/icon */
+			.cxtmenu-disabled {
+				opacity: 0.333;
+			}
+		</style>
+
+		<script>
+			window.addEventListener('DOMContentLoaded', function(){
+
+				var cy = window.cy = cytoscape({
+					container: document.getElementById('cy'),
+
+					ready: function(){
+					},
+
+					style: [
+						{
+							selector: 'node',
+							css: {
+								'content': 'data(name)'
+							}
+						},
+
+						{
+							selector: 'edge',
+							css: {
+								'curve-style': 'bezier',
+								'target-arrow-shape': 'triangle'
+							}
+						}
+					],
+
+					elements: {
+						nodes: [
+							{ data: { id: 'j', name: 'Jerry' } },
+							{ data: { id: 'e', name: 'Elaine' } },
+							{ data: { id: 'k', name: 'Kramer' } },
+							{ data: { id: 'g', name: 'George' } }
+						],
+						edges: [
+							{ data: { source: 'j', target: 'e' } },
+							{ data: { source: 'j', target: 'k' } },
+							{ data: { source: 'j', target: 'g' } },
+							{ data: { source: 'e', target: 'j' } },
+							{ data: { source: 'e', target: 'k' } },
+							{ data: { source: 'k', target: 'j' } },
+							{ data: { source: 'k', target: 'e' } },
+							{ data: { source: 'k', target: 'g' } },
+							{ data: { source: 'g', target: 'j' } }
+						]
+					}
+				});
+
+				cy.cxtmenu({
+					selector: 'node, edge',
+					outsideMenuCancel: 10,
+					commands: [
+						{
+							content: '<span class="fa fa-flash fa-2x"></span>',
+							select: function(ele){
+								console.log( ele.id() );
+							}
+						},
+
+						{
+							content: '<span class="fa fa-star fa-2x"></span>',
+							select: function(ele){
+								console.log( ele.data('name') );
+							},
+							enabled: false
+						},
+
+						{
+							content: 'Text',
+							select: function(ele){
+								console.log( ele.position() );
+							}
+						}
+					]
+				});
+
+				cy.cxtmenu({
+					selector: 'core',
+					outsideMenuCancel: 10,
+					commands: [
+						{
+							content: 'bg1',
+							select: function(){
+								console.log( 'bg1' );
+							}
+						},
+
+						{
+							content: 'bg2',
+							select: function(){
+								console.log( 'bg2' );
+							}
+						}
+					]
+				});
+
+			});
+		</script>
+	</head>
+
+	<body>
+		<h1>cytoscape-cxtmenu demo with cancel outside menu<</h1>
+
+		<div id="cy"></div>
+
+	</body>
+
+</html>

--- a/src/cxtmenu.js
+++ b/src/cxtmenu.js
@@ -497,7 +497,9 @@ let cxtmenu = function(params){
         }
 
         r = rw/2 + (options.menuRadius instanceof Function ? options.menuRadius(target) : Number(options.menuRadius));
-        if( d < rs + options.spotlightPadding ){
+        if( d < rs + options.spotlightPadding
+            || (options.outsideMenuCancel && d > r + options.activePadding)){ //
+
           queueDrawBg(r, rs);
           return;
         }
@@ -532,7 +534,6 @@ let cxtmenu = function(params){
           theta1 += dtheta;
           theta2 += dtheta;
         }
-
         queueDrawCommands( rx, ry, r, theta, rs );
       })
 
@@ -540,7 +541,6 @@ let cxtmenu = function(params){
 
       .on('cxttapend tapend', function(){
         parent.style.display = 'none';
-
         if( activeCommandI !== undefined ){
           let select = commands[ activeCommandI ].select;
 

--- a/src/cxtmenu.js
+++ b/src/cxtmenu.js
@@ -498,7 +498,7 @@ let cxtmenu = function(params){
 
         r = rw/2 + (options.menuRadius instanceof Function ? options.menuRadius(target) : Number(options.menuRadius));
         if( d < rs + options.spotlightPadding
-            || (options.outsideMenuCancel && d > r + options.activePadding)){ //
+            || (typeof options.outsideMenuCancel === "number" && d > r + options.activePadding + options.outsideMenuCancel)){ //
 
           queueDrawBg(r, rs);
           return;

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -28,7 +28,7 @@ let defaults = {
   itemTextShadowColor: 'transparent', // the text shadow colour of the command's content
   zIndex: 9999, // the z-index of the ui div
   atMouse: false, // draw menu at mouse position
-  outsideMenuCancel: false // if true, this will cancel the command if the pointer is released outside of the spotlight
+  outsideMenuCancel: false // if set to a number, this will cancel the command if the pointer is released outside of the spotlight, padded by the number given
 };
 
 module.exports = defaults;

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -27,7 +27,8 @@ let defaults = {
   itemColor: 'white', // the colour of text in the command's content
   itemTextShadowColor: 'transparent', // the text shadow colour of the command's content
   zIndex: 9999, // the z-index of the ui div
-  atMouse: false // draw menu at mouse position
+  atMouse: false, // draw menu at mouse position
+  outsideMenuCancel: false // if true, this will cancel the command if the pointer is released outside of the spotlight
 };
 
 module.exports = defaults;


### PR DESCRIPTION
Hi there,
This implements the behavior discussed in https://github.com/cytoscape/cytoscape.js-cxtmenu/issues/81#issuecomment-523057425 , with the option to set extra padding outside the spotlight before canceling. The default option is set to false. Implementation is relatively straightforward, but let me know if there are issues.